### PR TITLE
Update image ref and point to quay.io

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: multicloud-operators-channel
           # Replace this with the built image name
-          image: REPLACE_IMAGE
+          image: quay.io/multicloudlab/multicloud-operators-channel
           command:
           - multicloud-operators-channel
           imagePullPolicy: Always


### PR DESCRIPTION
Image is set to quay.io/multicloud/multicloud-operators-channel

Signed-off-by: Richard Su <rwsu@redhat.com>