### PR TITLE
requeue channel when cant list clusters

### DIFF
--- a/pkg/controller/channel/channel_controller.go
+++ b/pkg/controller/channel/channel_controller.go
@@ -388,21 +388,6 @@ func (r *ReconcileChannel) validateClusterRBAC(instance *chv1.Channel) error {
 
 	var subjects []rbac.Subject
 
-	clusterCRD := &apiextensionsv1beta1.CustomResourceDefinition{}
-	clusterCRDKey := types.NamespacedName{
-		Name: clusterCRDName,
-	}
-
-	if err := r.Get(context.TODO(), clusterCRDKey, clusterCRD); err != nil {
-		klog.V(debugLevel).Infof("skipping role binding for %v/%v since cluste CRD is not ready, err %v", instance.Name, instance.Namespace, err)
-
-		if kerr.IsNotFound(err) {
-			return nil
-		}
-
-		return gerr.Wrap(err, "failed to list cluster CRD")
-	}
-
 	cllist := &clusterv1alpha1.ClusterList{}
 
 	if err := r.List(context.TODO(), cllist, &client.ListOptions{}); err != nil {

--- a/pkg/controller/channel/channel_controller_test.go
+++ b/pkg/controller/channel/channel_controller_test.go
@@ -311,25 +311,11 @@ func TestChannelReconcileWithoutClusterCRD(t *testing.T) {
 	rq := reconcile.Request{NamespacedName: chKey}
 
 	_, err = rec.Reconcile(rq)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	updatedSrt := &corev1.Secret{}
-	g.Expect(c.Get(
-		context.TODO(),
-		types.NamespacedName{Name: refSrtName, Namespace: targetNamespace},
-		updatedSrt)).NotTo(gomega.HaveOccurred())
-
-	assertReferredObjAnno(t, updatedSrt, chKey.String())
+	g.Expect(err).Should(gomega.HaveOccurred())
 
 	expectedRole := &rbac.Role{}
 	g.Expect(c.Get(
 		context.TODO(),
 		types.NamespacedName{Name: chn.Name, Namespace: chn.Namespace},
 		expectedRole)).NotTo(gomega.HaveOccurred())
-
-	expectedRolebinding := &rbac.RoleBinding{}
-	g.Expect(c.Get(
-		context.TODO(),
-		types.NamespacedName{Name: chn.Name, Namespace: chn.Namespace},
-		expectedRolebinding)).NotTo(gomega.HaveOccurred())
 }


### PR DESCRIPTION
Signed-off-by: ianzhang366 <ian.w.zhang@redhat.com>

since we can't rely on `get crd kind` to tell if the cluster CRD is present at the cluster or not, changing the logic to re-queue the channel reconcile when can't list the cluster resource. Do so, will make sure on a ACM delploy, once the mcmapiserver is running, the channel will be able to generate the role binding properly.

I will create a new issue to decouple the cluster CRD and channel reconcile logic

