### PR TITLE
Do not delete subscription type deployables (#62)

### DIFF
--- a/pkg/apis/apps/v1/channel_types.go
+++ b/pkg/apis/apps/v1/channel_types.go
@@ -25,6 +25,10 @@ var (
 	KeyChannelSource = SchemeGroupVersion.Group + "/hosting-deployable"
 	// KeyChannel is namespacedname tells the source of the channel
 	KeyChannel = SchemeGroupVersion.Group + "/channel"
+	// KeyChannelType is the type of the source of the channel
+	KeyChannelType = SchemeGroupVersion.Group + "/channel-type"
+	// KeyChannelPath is the filter reference path of GitHub type channel
+	KeyChannelPath = SchemeGroupVersion.Group + "/channel-path"
 	// ServingChannel tells the channel that the secrect or configMap refers to
 	ServingChannel = SchemeGroupVersion.Group + "/serving-channel"
 )

--- a/pkg/synchronizer/helmreposynchronizer/helmreposynchronizer.go
+++ b/pkg/synchronizer/helmreposynchronizer/helmreposynchronizer.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -145,6 +146,23 @@ func (sync *ChannelSynchronizer) syncChannel(chn *chv1.Channel, localIdxFunc uti
 
 	// retrieve deployable list in current channel namespace
 	listopt := &client.ListOptions{Namespace: chn.Namespace}
+
+	// Handle deployables from multiple channels in the same namespace
+	chLabel := make(map[string]string)
+	chLabel[chv1.KeyChannel] = chn.Name
+	chLabel[chv1.KeyChannelType] = string(chn.Spec.Type)
+	labelSelector := &metav1.LabelSelector{
+		MatchLabels: chLabel,
+	}
+
+	clSelector, err := deputils.ConvertLabels(labelSelector)
+	if err != nil {
+		klog.Error("Failed to set label selector. err: ", err)
+		return
+	}
+
+	listopt.LabelSelector = clSelector
+
 	dpllist := &dplv1.DeployableList{}
 
 	err = sync.kubeClient.List(context.TODO(), dpllist, listopt)
@@ -189,6 +207,12 @@ func (sync *ChannelSynchronizer) syncChannel(chn *chv1.Channel, localIdxFunc uti
 			dplanno[dplv1.AnnotationDeployableVersion] = mv
 
 			dpl.SetAnnotations(dplanno)
+
+			dplLabels := make(map[string]string)
+			dplLabels[chv1.KeyChannel] = chn.Name
+			dplLabels[chv1.KeyChannelType] = string(chn.Spec.Type)
+			dpl.SetLabels(dplLabels)
+
 			dpl.Spec.Template = &runtime.RawExtension{}
 			dpl.Spec.Template.Raw, err = json.Marshal(obj)
 
@@ -222,6 +246,13 @@ func (sync *ChannelSynchronizer) processDeployable(chn *chv1.Channel,
 
 	if obj.GetKind() != utils.HelmCRKind || obj.GetAPIVersion() != utils.HelmCRAPIVersion {
 		klog.Info("Skipping non helm chart deployable:", obj.GetKind(), ".", obj.GetAPIVersion())
+		return
+	}
+
+	// Do not delete deployables with Subscription template kind. This causes problems if subscription
+	// and channel are in the same namespace.
+	if obj.GetKind() == utils.SubscriptionCRKind {
+		klog.Info("Skipping subscription deployable:", dpl.Name, ".", obj.GetKind())
 		return
 	}
 

--- a/pkg/utils/github_test.go
+++ b/pkg/utils/github_test.go
@@ -41,7 +41,7 @@ func Test_CloneGitRepo(t *testing.T) {
 		},
 	}
 
-	idx, resDirMap, err := CloneGitRepo(chn, nil, FakeClone)
+	_, idx, resDirMap, err := CloneGitRepo(chn, nil, FakeClone)
 
 	if err != nil {
 		t.Errorf("failed to clone %+v", err)

--- a/pkg/utils/utilconsts.go
+++ b/pkg/utils/utilconsts.go
@@ -23,8 +23,10 @@ const (
 	debugLevel = klog.Level(5)
 	// HelmCRKind is kind of the Helm CR
 	HelmCRKind = "HelmRelease"
+	// SubscriptionCRKind is kind of the Subscription CR
+	SubscriptionCRKind = "Subscription"
 	// HelmCRAPIVersion is APIVersion of the Helm CR
-	HelmCRAPIVersion = "app.ibm.com/v1alpha1"
+	HelmCRAPIVersion = "apps.open-cluster-management.io/v1"
 	// HelmCRChartName is spec.ChartName of the Helm CR
 	HelmCRChartName = "chartName"
 	// HelmCRReleaseName is spec.ReleaseName of the Helm CR


### PR DESCRIPTION
* Do not delete subscription type deployables

* Update utilconsts.go

* Update utilconsts.go

* Revert "Update utilconsts.go"

This reverts commit bb7ed89dd745c2e968ba4b62eaf9a78f528f9ea2.

* Revert "Revert "Update utilconsts.go""

This reverts commit f0ceecab78a9cf3af984b5480202290eaecfca81.

* Revert "Update utilconsts.go"

This reverts commit a8889b5d5a208d1c1bf384c69de3d5f350d36348.

* Update utilconsts.go

* Support multiple channels in same namespace

* Update helmreposynchronizer.go

* Update helmreposynchronizer.go

Co-authored-by: Roke Jung <rjung@redhat.com>