### PR TITLE
loosen up the validation check

### DIFF
--- a/pkg/webhook/channel_validator.go
+++ b/pkg/webhook/channel_validator.go
@@ -57,7 +57,8 @@ func (v *ChannelValidator) Handle(ctx context.Context, req admission.Request) ad
 	}
 
 	if !isAllGit(chList) {
-		return admission.Denied(fmt.Sprint("there's channel in the requested namespace"))
+		return admission.Denied(fmt.Sprintf("there's channel %v in the requested namespace %v",
+			chn.GetName(), chn.GetNamespace()))
 	}
 
 	return admission.Allowed("")

--- a/pkg/webhook/wireupwebhook.go
+++ b/pkg/webhook/wireupwebhook.go
@@ -241,7 +241,7 @@ func newValidatingWebhookCfg(wbhSvcName, validatorName, namespace, path string, 
 				},
 				Operations: []admissionregistration.OperationType{
 					admissionregistration.Create,
-					admissionregistration.Update,
+					//update should be a ok path, admissionregistration.Update,
 				},
 			}},
 		}},


### PR DESCRIPTION
This PR addresses the following issue,
1. validation only run when creating a `channel`, skip the `update` event
2. provide more details in the reject error message

Signed-off-by: Ian Zhang <izhang@redhat.com>