### PR TITLE
adding labels for object deployables

### DIFF
--- a/pkg/controller/deployable/deployable_controller.go
+++ b/pkg/controller/deployable/deployable_controller.go
@@ -336,7 +336,7 @@ func (r *ReconcileDeployable) propagateDeployableToChannel(
 		chv1.KeyChannelType: string(channel.Spec.Type),
 	}
 
-	addOrAppendChannelLabel(chdpl, addL)
+	utils.AddOrAppendChannelLabel(chdpl, addL)
 
 	exdpl, ok := dplmap[chkey]
 
@@ -380,23 +380,6 @@ func (r *ReconcileDeployable) propagateDeployableToChannel(
 	delete(dplmap, chkey)
 
 	return err
-}
-
-func addOrAppendChannelLabel(dpl *dplv1.Deployable, addL map[string]string) {
-	if dpl == nil || len(addL) == 0 {
-		return
-	}
-
-	curL := dpl.GetLabels()
-	if len(curL) == 0 {
-		curL = make(map[string]string)
-	}
-
-	for k, v := range addL {
-		curL[k] = v
-	}
-
-	dpl.SetLabels(curL)
 }
 
 func (r *ReconcileDeployable) promoteDeployabeToChannels(

--- a/pkg/controller/deployable/deployable_controller_test.go
+++ b/pkg/controller/deployable/deployable_controller_test.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	chv1 "github.com/open-cluster-management/multicloud-operators-channel/pkg/apis/apps/v1"
+	"github.com/open-cluster-management/multicloud-operators-channel/pkg/utils"
 	dplv1 "github.com/open-cluster-management/multicloud-operators-deployable/pkg/apis/apps/v1"
 )
 
@@ -422,7 +423,7 @@ var _ = Describe("test deployable label operations", func() {
 			tdpl := dpl.DeepCopy()
 			tl := tdpl.GetLabels()
 			tdpl.SetLabels(tl)
-			addOrAppendChannelLabel(tdpl, tt.add)
+			utils.AddOrAppendChannelLabel(tdpl, tt.add)
 			tlabel := tdpl.GetLabels()
 			Expect(cmp.Equal(tlabel, tt.expected)).Should(BeTrue())
 		}

--- a/pkg/utils/deployable.go
+++ b/pkg/utils/deployable.go
@@ -17,6 +17,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -305,4 +306,47 @@ func DplGenerateNameStr(deployable *dplv1.Deployable) string {
 	}
 
 	return gn
+}
+
+//AAddOrAppendChannelLabel append the give labels to dpl
+func AddOrAppendChannelLabel(dpl *dplv1.Deployable, addL map[string]string) {
+	if dpl == nil || len(addL) == 0 {
+		return
+	}
+
+	curL := dpl.GetLabels()
+	if len(curL) == 0 {
+		curL = make(map[string]string)
+	}
+
+	for k, v := range addL {
+		curL[k] = v
+	}
+
+	dpl.SetLabels(curL)
+}
+
+func SplitStringToTypes(s string) types.NamespacedName {
+	n := len(s)
+	ans := types.NamespacedName{}
+
+	if n == 0 {
+		return ans
+	}
+
+	sp := strings.Split(s, "/")
+	a, b := sp[0], sp[1]
+
+	if b == "" {
+		return ans
+	}
+
+	ans.Name = b
+	ans.Namespace = a
+
+	if ans.Namespace == "" {
+		ans.Namespace = "default"
+	}
+
+	return ans
 }

--- a/pkg/utils/deployable_test.go
+++ b/pkg/utils/deployable_test.go
@@ -689,3 +689,26 @@ func TestGenerateDeployableForChannel(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitStringToKey(t *testing.T) {
+	var tests = []struct {
+		name     string
+		given    string
+		expected types.NamespacedName
+	}{
+		{name: "only have name", given: "/test", expected: types.NamespacedName{Name: "test", Namespace: "default"}},
+		{name: "have name and ns", given: "chn/test", expected: types.NamespacedName{Name: "test", Namespace: "chn"}},
+		{name: "only have ns", given: "chn/", expected: types.NamespacedName{}},
+		{name: "only have name", given: "", expected: types.NamespacedName{}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			actual := utils.SplitStringToTypes(tt.given)
+			if actual != tt.expected {
+				t.Errorf("(%s): expected %s, actual %s", tt.given, tt.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Addressing [issue](https://github.com/open-cluster-management/backlog/issues/4106) by adding missing deployable labels, when user add an object to object bucket directly.

Signed-off-by: Ian Zhang <izhang@redhat.com>