### PR TITLE
clean up the outdate validatingconfig

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -238,7 +238,7 @@ func RunManager(sig <-chan struct{}) {
 
 	go func() {
 		if err := wiredWebhook.WireUpWebhookSupplymentryResource(caCert,
-			chv1.SchemeGroupVersion.WithKind(kindName), []admissionv1.OperationType{admissionv1.Create}); err != nil {
+			chv1.SchemeGroupVersion.WithKind(kindName), []admissionv1.OperationType{admissionv1.Create}, chWebhook.DelPreValiationCfg20); err != nil {
 			logger.Error(err, "failed to set up webhook configuration")
 			os.Exit(exitCode)
 		}


### PR DESCRIPTION
Signed-off-by: Ian Zhang <izhang@redhat.com>

Addressing [issue](https://github.com/open-cluster-management/backlog/issues/5696)

Basically, from 2.0.3 to 2.1 we change the `validatingwebhookconfiguration` naming format, however, k8s is stilling send the validation request to the older version of `validatingwebhookconfiguration`.

Now adding clean up logic in 2.1 to make sure there's only one active `validatingwebhookconfiguration` after the update.