### PR TITLE
Add insecureSkipVerify into spec

### DIFF
--- a/deploy/crds/apps.open-cluster-management.io_channels_crd.yaml
+++ b/deploy/crds/apps.open-cluster-management.io_channels_crd.yaml
@@ -138,6 +138,10 @@ spec:
                 name:
                   type: string
               type: object
+            insecureSkipVerify:
+              description: Skip server TLS certificate verification for Git or Helm
+                channel.
+              type: boolean
             pathname:
               description: For a `namespace` channel, pathname is the name of the
                 namespace; For a `helmrepo` or `github` channel, pathname is the remote

--- a/pkg/apis/apps/v1/channel_types.go
+++ b/pkg/apis/apps/v1/channel_types.go
@@ -85,6 +85,9 @@ type ChannelSpec struct {
 	// For a `objectbucket` channel, pathname is the URL and name of the bucket.
 	Pathname string `json:"pathname"`
 
+	// Skip server TLS certificate verification for Git or Helm channel.
+	InsecureSkipVerify bool `json:"insecureSkipVerify"`
+
 	// For a `github` channel or a `helmrepo` channel on github, this
 	// can be used to reference a Secret which contains the credentials for
 	// authentication, i.e. `user` and `accessToken`.

--- a/pkg/apis/apps/v1/zz_generated.openapi.go
+++ b/pkg/apis/apps/v1/zz_generated.openapi.go
@@ -189,6 +189,12 @@ func schema_pkg_apis_apps_v1_ChannelSpec(ref common.ReferenceCallback) common.Op
 							Format: "",
 						},
 					},
+					"insecureSkipVerify": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 					"secretRef": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("k8s.io/api/core/v1.ObjectReference"),

--- a/pkg/synchronizer/helmreposynchronizer/helmreposynchronizer.go
+++ b/pkg/synchronizer/helmreposynchronizer/helmreposynchronizer.go
@@ -115,7 +115,7 @@ func (sync *ChannelSynchronizer) syncChannel(chn *chv1.Channel, localIdxFunc uti
 		}
 	}
 	// retrieve helm chart list from helm repo
-	idx, err := utils.GetHelmRepoIndex(chn.Spec.Pathname, chnRefCfgMap, localIdxFunc, logf)
+	idx, err := utils.GetHelmRepoIndex(chn.Spec.Pathname, chn.Spec.InsecureSkipVerify, chnRefCfgMap, localIdxFunc, logf)
 	if err != nil {
 		logf.Error(err, fmt.Sprintf("error getting index for channel %v/%v", chn.Namespace, chn.Name))
 		return

--- a/pkg/utils/helmrepo_test.go
+++ b/pkg/utils/helmrepo_test.go
@@ -26,7 +26,7 @@ const (
 )
 
 func TestGetHelmRepoIndex(t *testing.T) {
-	idx, err := GetHelmRepoIndex(helmTests, nil, LoadLocalIdx, tlog.NullLogger{})
+	idx, err := GetHelmRepoIndex(helmTests, false, nil, LoadLocalIdx, tlog.NullLogger{})
 
 	if err != nil {
 		t.Errorf("failed to clone %+v", err)


### PR DESCRIPTION
Support both config map and `spec.insecureSkipVerify` to skip server TLS certificate verification.

```
apiVersion: apps.open-cluster-management.io/v1
kind: Channel
metadata:
  name: dev-helmrepo
  namespace: dev
spec:
    type: HelmRepo
    pathname: http://kubernetes-charts.storage.googleapis.com/
    configMapRef: 
      name: skip-cert-verify
      apiVersion: v1
      kind: ConfigMap
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: skip-cert-verify
  namespace: dev
data:
  insecureSkipVerify: "true"
```

and 

```
apiVersion: apps.open-cluster-management.io/v1
kind: Channel
metadata:
  name: dev-helmrepo
  namespace: dev
spec:
    type: HelmRepo
    pathname: http://kubernetes-charts.storage.googleapis.com/
    insecureSkipVerify: true
```