### PR TITLE
make sure deployable generate by the git_sync is not reconciled on ch…

### DIFF
--- a/pkg/controller/deployable/deployable_controller.go
+++ b/pkg/controller/deployable/deployable_controller.go
@@ -55,7 +55,7 @@ var (
 	// AnnotationHosting defines the subscription hosting the resource
 	AnnotationSubHosting = chv1.SchemeGroupVersion.Group + "/hosting-subscription"
 	AnnotationDplHosting = chv1.SchemeGroupVersion.Group + "/hosting-deployable"
-	LableHosting         = chv1.SchemeGroupVersion.Group + "/subscription"
+	LabelHosting         = chv1.SchemeGroupVersion.Group + "/subscription"
 )
 
 /**
@@ -117,7 +117,7 @@ func isSubDeployable(in metav1.Object) bool {
 
 	lab := in.GetLabels()
 
-	if _, ok := lab[LableHosting]; ok {
+	if _, ok := lab[LabelHosting]; ok {
 		return true
 	}
 

--- a/pkg/controller/deployable/deployable_controller.go
+++ b/pkg/controller/deployable/deployable_controller.go
@@ -53,8 +53,9 @@ const (
 
 var (
 	// AnnotationHosting defines the subscription hosting the resource
-	AnnotationHosting = chv1.SchemeGroupVersion.Group + "/hosting-subscription"
-	LableHosting      = chv1.SchemeGroupVersion.Group + "subscription"
+	AnnotationSubHosting = chv1.SchemeGroupVersion.Group + "/hosting-subscription"
+	AnnotationDplHosting = chv1.SchemeGroupVersion.Group + "/hosting-deployable"
+	LableHosting         = chv1.SchemeGroupVersion.Group + "/subscription"
 )
 
 /**
@@ -106,7 +107,11 @@ func (mapper *channelMapper) Map(obj handler.MapObject) []reconcile.Request {
 func isSubDeployable(in metav1.Object) bool {
 	anno := in.GetAnnotations()
 
-	if _, ok := anno[AnnotationHosting]; ok {
+	if _, ok := anno[AnnotationSubHosting]; ok {
+		return true
+	}
+
+	if _, ok := anno[AnnotationDplHosting]; ok {
 		return true
 	}
 


### PR DESCRIPTION
Making sure the deployable generated by the subscription operator is not reconciled
on channel operator.

There're 2 types of deployable generated by subscription,
1. deployable with annotation as `hosting-subscription`(generated by
   subscription reconcile logic)
2. deployable with the label as `subscription` (generated by the git_sync logic)

The issue is reported at:
https://github.com/open-cluster-management/backlog/issues/7105
Signed-off-by: Ian Zhang <izhang@redhat.com>